### PR TITLE
Added `make` method and tests

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,12 @@
+<?php
+// .phpstorm.meta.php
+
+namespace PHPSTORM_META {
+
+    override(
+        \Yiisoft\Injector\Injector::make(0),
+        map([
+            '' => '@',
+        ])
+    );
+}

--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@
     <br>
 </p>
 
-The package is PSR-11 compatible injector that is able to invoke methods resolving their dependencies via autowiring.
+The package is PSR-11 compatible injector that is able to invoke methods or create objects resolving their dependencies
+via autowiring.
 
 [![Latest Stable Version](https://poser.pugx.org/yiisoft/injector/v/stable.png)](https://packagist.org/packages/yiisoft/injector)
 [![Total Downloads](https://poser.pugx.org/yiisoft/injector/downloads.png)](https://packagist.org/packages/yiisoft/injector)
 [![Build Status](https://travis-ci.com/yiisoft/injector.svg?branch=master)](https://travis-ci.com/yiisoft/injector)
 [![Code Coverage](https://scrutinizer-ci.com/g/yiisoft/injector/badges/coverage.png)](https://scrutinizer-ci.com/g/yiisoft/injector/)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/yiisoft/injector/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/yiisoft/injector/?branch=master)
+
+## Features
+
+- Invoke callable or create and object of a given class.
+- Resolve dependencies by parameter types using the given container.
+- Pass concrete dependency instances by type.
+- Pass arguments by name.
 
 ## General usage
 
@@ -41,6 +49,8 @@ Sometimes you either don't have an object in container or want to explicitly spe
 like the following:
 
 ```php
+use Yiisoft\Injector\Injector;
+
 /** @var $dataProvider DataProvider */
 $dataProvider = /* ... */;
 $result = (new Injector($container))->invoke([$calculator, 'calculate'], ['multiplier' => 5.0, $dataProvider]);
@@ -58,3 +68,18 @@ public function calculate(DataProvider $dataProvider, float $multiplier)
 We have passed two arguments. One is `multiplier`. It is explicitly named. Such arguments passed as is. Another is 
 data provider. It is not named explicitly so injector finds matching parameter that has the same type.
 
+Creating an instance of an object of a given class behaves similar to `invoke()`:
+
+```php
+use Yiisoft\Injector\Injector;
+
+class StringFormatter
+{
+    public function __construct($string, \Yiisoft\I18n\MessageFormatterInterface $formatter)
+    {
+        // ...
+    }
+}
+
+$stringFormatter = (new Injector($container))->make(StringFormatter::class, ['string' => 'Hello World!']);
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <br>
 </p>
 
-The package is PSR-11 compatible injector that is able to invoke methods or create objects resolving their dependencies
+The package is [PSR-11](http://www.php-fig.org/psr/psr-11/) compatible injector that is able to invoke methods or create objects resolving their dependencies
 via autowiring.
 
 [![Latest Stable Version](https://poser.pugx.org/yiisoft/injector/v/stable.png)](https://packagist.org/packages/yiisoft/injector)
@@ -18,7 +18,7 @@ via autowiring.
 ## Features
 
 - Invoke callable or create and object of a given class.
-- Resolve dependencies by parameter types using the given container.
+- Resolve dependencies by parameter types using the given [PSR-11](http://www.php-fig.org/psr/psr-11/) container.
 - Pass concrete dependency instances by type.
 - Pass arguments by name.
 
@@ -83,3 +83,5 @@ class StringFormatter
 
 $stringFormatter = (new Injector($container))->make(StringFormatter::class, ['string' => 'Hello World!']);
 ```
+
+## 

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -23,7 +23,7 @@ final class Injector
     }
 
     /**
-     * Invoke a callback with resolving dependencies in parameters.
+     * Invoke a callback with resolving dependencies based on parameter types.
      *
      * This methods allows invoking a callback and let type hinted parameter names to be
      * resolved as objects of the Container. It additionally allow calling function passing named arguments.
@@ -34,7 +34,9 @@ final class Injector
      * $formatString = function($string, \Yiisoft\I18n\MessageFormatterInterface $formatter) {
      *    // ...
      * }
-     * $container->invoke($formatString, ['string' => 'Hello World!']);
+     *
+     * $injector = new Yiisoft\Injector\Injector($container);
+     * $injector->invoke($formatString, ['string' => 'Hello World!']);
      * ```
      *
      * This will pass the string `'Hello World!'` as the first argument, and a formatter instance created
@@ -44,7 +46,7 @@ final class Injector
      * @param array $arguments The array of the function arguments.
      * This can be either a list of arguments, or an associative array where keys are argument names.
      * @return mixed the callable return value.
-     * @throws MissingRequiredArgumentException  if required argument is missing.
+     * @throws MissingRequiredArgumentException if required argument is missing.
      * @throws ContainerExceptionInterface if a dependency cannot be resolved or if a dependency cannot be fulfilled.
      * @throws ReflectionException
      */
@@ -64,9 +66,33 @@ final class Injector
     }
 
     /**
-     * @param string $class
-     * @param array $arguments
-     * @return mixed
+     * Creates an object of a given class with resolving constructor dependencies based on parameter types.
+     *
+     * This methods allows invoking a constructor and let type hinted parameter names to be
+     * resolved as objects of the Container. It additionally allow calling constructor passing named arguments.
+     *
+     * For example, the following constructor may be invoked using the Container to resolve the formatter dependency:
+     *
+     * ```php
+     * class StringFormatter
+     * {
+     *     public function __construct($string, \Yiisoft\I18n\MessageFormatterInterface $formatter)
+     *     {
+     *         // ...
+     *     }
+     * }
+     * 
+     * $injector = new Yiisoft\Injector\Injector($container);
+     * $stringFormatter = $injector->make(StringFormatter::class, ['string' => 'Hello World!']);
+     * ```
+     *
+     * This will pass the string `'Hello World!'` as the first argument, and a formatter instance created
+     * by the DI container as the second argument.
+     *
+     * @param string $class name of the class to be created.
+     * @param array $arguments The array of the function arguments.
+     * This can be either a list of arguments, or an associative array where keys are argument names.
+     * @return mixed object of the given class.
      * @throws ContainerExceptionInterface
      * @throws MissingRequiredArgumentException|InvalidArgumentException
      * @throws ReflectionException
@@ -87,14 +113,17 @@ final class Injector
     }
 
     /**
-     * @param \ReflectionFunctionAbstract $reflection
-     * @param array $arguments
-     * @return array
+     * Resolve dependencies for the given function reflection object and a list of concrete arguments
+     * and return array of arguments to call the function with.
+     *
+     * @param \ReflectionFunctionAbstract $reflection function reflection.
+     * @param array $arguments concrete arguments.
+     * @return array resolved arguments.
      * @throws ContainerExceptionInterface
      * @throws MissingRequiredArgumentException|InvalidArgumentException
      * @throws ReflectionException
      */
-    private function resolveDependencies(\ReflectionFunctionAbstract $reflection, array $arguments = [])
+    private function resolveDependencies(\ReflectionFunctionAbstract $reflection, array $arguments = []): array
     {
         $resolvedArguments = [];
 

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -101,7 +101,7 @@ final class Injector
     {
         $classReflection = new \ReflectionClass($class);
         if (!$classReflection->isInstantiable()) {
-            throw new \InvalidArgumentException("Class $class is not instantiable");
+            throw new \InvalidArgumentException("Class $class is not instantiable.");
         }
         $reflection = $classReflection->getConstructor();
         if ($reflection === null) {

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -80,7 +80,7 @@ final class Injector
         $reflection = $classReflection->getConstructor();
         if ($reflection === null) {
             // Method __construct() does not exist
-            return new $class;
+            return new $class();
         }
 
         return new $class(...$this->resolveDependencies($reflection, $arguments));

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -81,7 +81,7 @@ final class Injector
      *         // ...
      *     }
      * }
-     * 
+     *
      * $injector = new Yiisoft\Injector\Injector($container);
      * $stringFormatter = $injector->make(StringFormatter::class, ['string' => 'Hello World!']);
      * ```

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -71,7 +71,7 @@ class InjectorTest extends TestCase
     public function testInvokeAnonymousClass(): void
     {
         $container = new Container([EngineInterface::class => EngineMarkTwo::class]);
-        $class = new class () {
+        $class = new class() {
             public EngineInterface $engine;
             public function setEngine(EngineInterface $engine)
             {
@@ -518,7 +518,7 @@ class InjectorTest extends TestCase
     {
         $container = new Container([]);
 
-        $values = [new EngineMarkTwo, new EngineVAZ2101()];
+        $values = [new EngineMarkTwo(), new EngineVAZ2101()];
         $object = (new Injector($container))->make(MakeEngineCollector::class, $values);
 
         $this->assertSame($values, $object->engines);

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Injector\Tests;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
 use Yiisoft\Di\Container;
@@ -16,6 +17,11 @@ use Yiisoft\Injector\Tests\Support\EngineMarkTwo;
 use Yiisoft\Injector\Tests\Support\EngineZIL130;
 use Yiisoft\Injector\Tests\Support\EngineVAZ2101;
 use Yiisoft\Injector\Tests\Support\LightEngine;
+use Yiisoft\Injector\Tests\Support\MakeEmptyConstructor;
+use Yiisoft\Injector\Tests\Support\MakeEngineCollector;
+use Yiisoft\Injector\Tests\Support\MakeEngineMatherWithParam;
+use Yiisoft\Injector\Tests\Support\MakeNoConstructor;
+use Yiisoft\Injector\Tests\Support\MakePrivateConstructor;
 
 class InjectorTest extends TestCase
 {
@@ -57,6 +63,25 @@ class InjectorTest extends TestCase
         $result = (new Injector($container))->invoke([EngineVAZ2101::class, 'isWroomWroom']);
 
         $this->assertIsBool($result);
+    }
+
+    /**
+     * Injector should be able to invoke static method.
+     */
+    public function testInvokeAnonymousClass(): void
+    {
+        $container = new Container([EngineInterface::class => EngineMarkTwo::class]);
+        $class = new class () {
+            public EngineInterface $engine;
+            public function setEngine(EngineInterface $engine)
+            {
+                $this->engine = $engine;
+            }
+        };
+
+        (new Injector($container))->invoke([$class, 'setEngine']);
+
+        $this->assertInstanceOf(EngineInterface::class, $class->engine);
     }
 
     /**
@@ -156,7 +181,7 @@ class InjectorTest extends TestCase
 
         $engineName = (new Injector($container))->invoke(
             $getEngineName,
-            [new \stdClass(), $needleEngine, new \DateTimeImmutable()]
+            [new \stdClass(), $needleEngine, new DateTimeImmutable()]
         );
 
         $this->assertSame(EngineZIL130::NAME, $engineName);
@@ -282,7 +307,7 @@ class InjectorTest extends TestCase
      */
     public function testVariadicArgumentUnnamedParams(): void
     {
-        $container = new Container([\DateTimeInterface::class => new \DateTimeImmutable()]);
+        $container = new Container([\DateTimeInterface::class => new DateTimeImmutable()]);
 
         $callable = fn (\DateTimeInterface $dateTime, EngineInterface ...$engines) => count($engines);
 
@@ -299,7 +324,7 @@ class InjectorTest extends TestCase
      */
     public function testVariadicMixedArgumentWithMixedParams(): void
     {
-        $container = new Container([\DateTimeInterface::class => new \DateTimeImmutable()]);
+        $container = new Container([\DateTimeInterface::class => new DateTimeImmutable()]);
 
         $callable = fn (...$engines) => $engines;
 
@@ -316,7 +341,7 @@ class InjectorTest extends TestCase
      */
     public function testVariadicStringArgumentWithUnnamedStringsParams(): void
     {
-        $container = new Container([\DateTimeInterface::class => new \DateTimeImmutable()]);
+        $container = new Container([\DateTimeInterface::class => new DateTimeImmutable()]);
 
         $callable = fn (string ...$engines) => $engines;
 
@@ -349,7 +374,7 @@ class InjectorTest extends TestCase
 
         $callable = fn (?EngineInterface $engine, $id = 'test') => func_num_args();
 
-        $result = (new Injector($container))->invoke($callable, [new \DateTimeImmutable(), new \DateTimeImmutable()]);
+        $result = (new Injector($container))->invoke($callable, [new DateTimeImmutable(), new DateTimeImmutable()]);
 
         $this->assertSame(4, $result);
     }
@@ -362,7 +387,7 @@ class InjectorTest extends TestCase
 
         $this->expectException(\Throwable::class);
 
-        (new Injector($container))->invoke($callable, ['engine' => new \DateTimeImmutable()]);
+        (new Injector($container))->invoke($callable, ['engine' => new DateTimeImmutable()]);
     }
 
     public function testArrayArgumentWithUnnamedType(): void
@@ -407,5 +432,116 @@ class InjectorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         (new Injector($container))->invoke($getEngineName, ['test']);
+    }
+
+    /**
+     * Constructor method not defined
+     */
+    public function testMakeWithoutConstructor(): void
+    {
+        $container = new Container([]);
+
+        $object = (new Injector($container))->make(MakeNoConstructor::class);
+
+        $this->assertInstanceOf(MakeNoConstructor::class, $object);
+    }
+
+    /**
+     * Constructor without arguments
+     */
+    public function testMakeWithoutArguments(): void
+    {
+        $container = new Container([]);
+
+        $object = (new Injector($container))->make(MakeEmptyConstructor::class);
+
+        $this->assertInstanceOf(MakeEmptyConstructor::class, $object);
+    }
+
+    /**
+     * Private constructor unavailable from Injector context
+     */
+    public function testMakeWithPrivateConstructor(): void
+    {
+        $container = new Container([]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/not instantiable/');
+
+        (new Injector($container))->make(MakePrivateConstructor::class);
+    }
+
+    public function testMakeInvalidClass(): void
+    {
+        $container = new Container([]);
+
+        $this->expectException(\ReflectionException::class);
+        $this->expectExceptionMessageMatches('/does not exist/');
+
+        (new Injector($container))->make(UndefinedClassThatShouldNotBeDefined::class);
+    }
+
+    public function testMakeInternalClass(): void
+    {
+        $container = new Container([]);
+        $object = (new Injector($container))->make(DateTimeImmutable::class);
+        $this->assertInstanceOf(DateTimeImmutable::class, $object);
+    }
+
+    public function testMakeAbstractClass(): void
+    {
+        $container = new Container([]);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/not instantiable/');
+        (new Injector($container))->make(LightEngine::class);
+    }
+
+    public function testMakeInterface(): void
+    {
+        $container = new Container([]);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/not instantiable/');
+        (new Injector($container))->make(EngineInterface::class);
+    }
+
+    public function testMakeWithVariadicFromContainer(): void
+    {
+        $container = new Container([EngineInterface::class => EngineMarkTwo::class]);
+
+        $object = (new Injector($container))->make(MakeEngineCollector::class, []);
+
+        $this->assertSame(1, count($object->engines));
+        $this->assertSame([$container->get(EngineInterface::class)], $object->engines);
+    }
+
+    public function testMakeWithVariadicFromArguments(): void
+    {
+        $container = new Container([]);
+
+        $values = [new EngineMarkTwo, new EngineVAZ2101()];
+        $object = (new Injector($container))->make(MakeEngineCollector::class, $values);
+
+        $this->assertSame($values, $object->engines);
+    }
+
+    public function testMakeWithCustomParam(): void
+    {
+        $container = new Container([EngineInterface::class => EngineMarkTwo::class]);
+
+        $object = (new Injector($container))
+            ->make(MakeEngineMatherWithParam::class, [new EngineVAZ2101(), 'parameter' => 'power']);
+
+        $this->assertNotSame($object->engine1, $object->engine2);
+        $this->assertSame($object->parameter, 'power');
+    }
+
+    public function testMakeWithInvalidCustomParam(): void
+    {
+        $container = new Container([EngineInterface::class => EngineMarkTwo::class]);
+
+        $this->expectException(\TypeError::class);
+
+        (new Injector($container))
+            ->make(MakeEngineMatherWithParam::class, ['parameter' => 100500]);
     }
 }

--- a/tests/Support/MakeEmptyConstructor.php
+++ b/tests/Support/MakeEmptyConstructor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Support;
+
+class MakeEmptyConstructor
+{
+    public function __construct()
+    {
+    }
+}

--- a/tests/Support/MakeEngineCollector.php
+++ b/tests/Support/MakeEngineCollector.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Support;
+
+class MakeEngineCollector
+{
+    public array $engines;
+    public function __construct(EngineInterface ...$engines)
+    {
+        $this->engines = $engines;
+    }
+}

--- a/tests/Support/MakeEngineMatherWithParam.php
+++ b/tests/Support/MakeEngineMatherWithParam.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Support;
+
+class MakeEngineMatherWithParam
+{
+    public EngineInterface $engine1;
+    public EngineInterface $engine2;
+    public string $parameter;
+    public function __construct(string $parameter, EngineInterface $engine1, EngineInterface $engine2)
+    {
+        $this->engine1 = $engine1;
+        $this->engine2 = $engine2;
+        $this->parameter = $parameter;
+    }
+}

--- a/tests/Support/MakeNoConstructor.php
+++ b/tests/Support/MakeNoConstructor.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Support;
+
+class MakeNoConstructor
+{
+}

--- a/tests/Support/MakePrivateConstructor.php
+++ b/tests/Support/MakePrivateConstructor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Support;
+
+class MakePrivateConstructor
+{
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Added the `make` method to Injector.

What for?
To create objects without saving them in a container.

Where is useful?
- In the primary pipeline: we can define middlewares by classname and resolve it with Injector.
- In the router: we can solve the problem of settling in the container of the controllers/middlewares instances. May contribute to the addition of custom parameters for a constructor of a middleware.
- In user code: when we does not need get and save an instance in our container and target class have a lot dependencies

Potential debuff: the dependencies of the created entity will be taken from the container and they will settle there.
I think in this case, we can use a Resetable container (better WeakReference container, but we don’t have it yet)

Example:

```php
$instance = (new Injector($container))->make(SomeClass::class, ['argument' => 'value']);
```

Todo:

* [x] Add docs
* [x] Check relevance of exceptions