### PR TITLE
Simplify invoke()

### DIFF
--- a/src/Injector.php
+++ b/src/Injector.php
@@ -52,17 +52,9 @@ final class Injector
      */
     public function invoke(callable $callable, array $arguments = [])
     {
-        if (\is_object($callable) && !$callable instanceof \Closure) {
-            $callable = [$callable, '__invoke'];
-        }
-
-        if (\is_array($callable)) {
-            $reflection = new \ReflectionMethod($callable[0], $callable[1]);
-        } else {
-            $reflection = new \ReflectionFunction($callable);
-        }
-
-        return \call_user_func_array($callable, $this->resolveDependencies($reflection, $arguments));
+        $callable = \Closure::fromCallable($callable);
+        $reflection = new \ReflectionFunction($callable);
+        return $reflection->invokeArgs($this->resolveDependencies($reflection, $arguments));
     }
 
     /**

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -17,6 +17,7 @@ use Yiisoft\Injector\Tests\Support\EngineInterface;
 use Yiisoft\Injector\Tests\Support\EngineMarkTwo;
 use Yiisoft\Injector\Tests\Support\EngineZIL130;
 use Yiisoft\Injector\Tests\Support\EngineVAZ2101;
+use Yiisoft\Injector\Tests\Support\Invokeable;
 use Yiisoft\Injector\Tests\Support\LightEngine;
 use Yiisoft\Injector\Tests\Support\MakeEmptyConstructor;
 use Yiisoft\Injector\Tests\Support\MakeEngineCollector;
@@ -455,6 +456,13 @@ class InjectorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         (new Injector($container))->invoke($getEngineName, ['test']);
+    }
+
+    public function testInvokeable(): void
+    {
+        $container = $this->getContainer();
+        $result = (new Injector($container))->invoke(new Invokeable());
+        $this->assertSame(42, $result);
     }
 
     /**

--- a/tests/Support/Invokeable.php
+++ b/tests/Support/Invokeable.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Yiisoft\Injector\Tests\Support;
+
+
+class Invokeable
+{
+    public function __invoke(): int
+    {
+        return 42;
+    }
+}

--- a/tests/Support/Invokeable.php
+++ b/tests/Support/Invokeable.php
@@ -3,7 +3,6 @@
 
 namespace Yiisoft\Injector\Tests\Support;
 
-
 class Invokeable
 {
     public function __invoke(): int


### PR DESCRIPTION
1. `\Closure::fromCallable()` is used instead of callable type checks.
2. Since we already have an instance of reflection we may call it instead of using `\call_user_func_array()`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
