### PR TITLE
Add context argument to invoke method

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,37 @@ public function calculate(DataProvider $dataProvider, float $multiplier)
 We have passed two arguments. One is `multiplier`. It is explicitly named. Such arguments passed as is. Another is 
 data provider. It is not named explicitly so injector finds matching parameter that has the same type.
 
+In case you need to call private method from within the class itself, you can pass context as a third argument:
+
+```php
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Yiisoft\Injector\Injector;
+
+class Worker
+{
+    public function run(ContainerInterface $container)
+    {
+        (new Injector($container))->invoke([$this, 'process'], [], $this);
+    }
+    
+    private function process(LoggerInterface $logger): void
+    {
+        //
+        $logger->info('Processing done.');
+    }
+}
+```
+
 Creating an instance of an object of a given class behaves similar to `invoke()`:
 
 ```php
+use Yiisoft\I18n\MessageFormatterInterface;
 use Yiisoft\Injector\Injector;
 
 class StringFormatter
 {
-    public function __construct($string, \Yiisoft\I18n\MessageFormatterInterface $formatter)
+    public function __construct($string, MessageFormatterInterface $formatter)
     {
         // ...
     }

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -45,14 +45,19 @@ final class Injector
      * @param callable $callable callable to be invoked.
      * @param array $arguments The array of the function arguments.
      * This can be either a list of arguments, or an associative array where keys are argument names.
+     * @param object|string $context Object or class name to context binding.
+     * If you want to bind only a static context then pass the class name here.
      * @return mixed the callable return value.
      * @throws MissingRequiredArgumentException if required argument is missing.
      * @throws ContainerExceptionInterface if a dependency cannot be resolved or if a dependency cannot be fulfilled.
      * @throws ReflectionException
      */
-    public function invoke(callable $callable, array $arguments = [])
+    public function invoke(callable $callable, array $arguments = [], $context = null)
     {
         $callable = \Closure::fromCallable($callable);
+        if ($context !== null) {
+            $callable = $callable->bindTo(is_string($context) ? null : $context, $context);
+        }
         $reflection = new \ReflectionFunction($callable);
         return $reflection->invokeArgs($this->resolveDependencies($reflection, $arguments));
     }

--- a/tests/Support/ContextMethod.php
+++ b/tests/Support/ContextMethod.php
@@ -18,4 +18,8 @@ class ContextMethod
     {
         return static::class;
     }
+    public static function publicStaticMethod(): string
+    {
+        return static::class;
+    }
 }

--- a/tests/Support/ContextMethod.php
+++ b/tests/Support/ContextMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Support;
+
+class ContextMethod
+{
+    private function privateMethod(): bool
+    {
+        return true;
+    }
+    protected function protectedMethod(): bool
+    {
+        return true;
+    }
+    private static function staticMethod(): string
+    {
+        return static::class;
+    }
+}

--- a/tests/Support/Invokeable.php
+++ b/tests/Support/Invokeable.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Yiisoft\Injector\Tests\Support;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Added context argument to invoke method

```php
// Object context
$closure = function () {
    return $this->getName();
};
$engine = new EngineMarkTwo();
echo (new Injector($container))->invoke($closure, [], $engine); // Mark Two

// Only static context (class name should be passed)
$closure = static function () {
    // call protected/private static methods
    // ...
    return self::class;
};
echo (new Injector($container))->invoke($closure, [], EngineMarkTwo::class); // \...\EngineMarkTwo
```


* [x] More tests
* [x] Docs about context?