### PR TITLE
Customization of identifier template

### DIFF
--- a/src/Injector.php
+++ b/src/Injector.php
@@ -276,6 +276,7 @@ final class Injector
                 try {
                     --$left;
                     $argument = $this->container->get(strtr($template, $toReplace));
+                    break;
                 } catch (NotFoundExceptionInterface $e) {
                     if ($left === 0) {
                         throw $e;

--- a/src/ResolvingState.php
+++ b/src/ResolvingState.php
@@ -86,6 +86,17 @@ final class ResolvingState
             ? [...$this->resolvedValues, ...$this->numericArguments]
             : $this->resolvedValues;
     }
+    /**
+     * @return array<string, string>
+     * @phan-suppress PhanPossiblyNullTypeReturn
+     */
+    public function getDataToTemplate(): array
+    {
+        if ($this->templateData === null) {
+            $this->prepareDataToTemplate();
+        }
+        return $this->templateData;
+    }
 
     /**
      * @param null|string $className
@@ -117,23 +128,12 @@ final class ResolvingState
             }
         }
     }
-
-    /**
-     * @return array<string, string>
-     */
-    public function getDataToTemplate(): array
-    {
-        if ($this->templateData === null) {
-            $this->prepareDataToTemplate();
-        }
-        return $this->templateData;
-    }
-
     private function prepareDataToTemplate(): void
     {
         $class = $this->reflection instanceof \ReflectionMethod
             ? $this->reflection->getDeclaringClass()
             : $this->reflection->getClosureScopeClass();
+
         $this->templateData = [
             Injector::TEMPLATE_METHOD => $this->reflection->getShortName(),
             Injector::TEMPLATE_CLASS => $class === null

--- a/src/ResolvingState.php
+++ b/src/ResolvingState.php
@@ -20,6 +20,8 @@ final class ResolvingState
     private array $namedArguments = [];
     private bool $shouldPushTrailingArguments;
     private array $resolvedValues = [];
+    /** @var null|array<string, string> */
+    private ?array $templateData = null;
 
     /**
      * @param ReflectionFunctionAbstract $reflection Function reflection.
@@ -114,5 +116,32 @@ final class ResolvingState
                 $this->namedArguments[$key] = &$value;
             }
         }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getDataToTemplate(): array
+    {
+        if ($this->templateData === null) {
+            $this->prepareDataToTemplate();
+        }
+        return $this->templateData;
+    }
+
+    private function prepareDataToTemplate(): void
+    {
+        $class = $this->reflection instanceof \ReflectionMethod
+            ? $this->reflection->getDeclaringClass()
+            : $this->reflection->getClosureScopeClass();
+        $this->templateData = [
+            Injector::TEMPLATE_METHOD => $this->reflection->getShortName(),
+            Injector::TEMPLATE_CLASS => $class === null
+                ? ''
+                : $class->getName(),
+            Injector::TEMPLATE_NAMESPACE => $class === null
+                ? $this->reflection->getNamespaceName()
+                : $class->getNamespaceName(),
+        ];
     }
 }

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -780,4 +780,25 @@ class InjectorTest extends BaseInjectorTest
         $this->assertSame($object1, $result[0]);
         $this->assertSame($object2, $result[1]);
     }
+
+    public function testIdTemplatesOrder(): void
+    {
+        $object1 = new DateTimeImmutable();
+        $object2 = new DateTimeImmutable();
+
+        $container = $this->getContainer([
+            'DateTimeInterface' => $object1,
+            'DateTimeInterface$param2' => $object2,
+        ]);
+        $injector = (new Injector($container))
+            ->withIdTemplates(
+                Injector::ID_TEMPLATE_PARAM_CLASS . '$' . Injector::ID_TEMPLATE_PARAM_NAME,
+                Injector::ID_TEMPLATE_PARAM_CLASS,
+            );
+
+        $result = $injector->invoke(fn (DateTimeInterface $param1, DateTimeInterface $param2) => [$param1, $param2]);
+
+        $this->assertSame($object1, $result[0]);
+        $this->assertSame($object2, $result[1]);
+    }
 }

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -735,4 +735,49 @@ class InjectorTest extends BaseInjectorTest
 
         (new Injector($container))->make(MakeEngineMatherWithParam::class, ['parameter' => 100500]);
     }
+
+    public function testWithIdTemplateImmutability(): void
+    {
+        $container = $this->getContainer([]);
+        $injector1 = new Injector($container);
+
+        $injector2 = $injector1->withIdTemplates(Injector::ID_TEMPLATE_PARAM_CLASS . '$');
+
+        $this->assertNotSame($injector1, $injector2);
+    }
+
+    public function testIdTemplateParamName(): void
+    {
+        $object1 = new DateTimeImmutable();
+        $object2 = new DateTimeImmutable();
+
+        $container = $this->getContainer([
+            'param1' => $object1,
+            'param2' => $object2,
+        ]);
+        $injector = (new Injector($container))->withIdTemplates(Injector::ID_TEMPLATE_PARAM_NAME);
+
+        $result = $injector->invoke(fn (DateTimeInterface $param1, DateTimeInterface $param2) => [$param1, $param2]);
+
+        $this->assertSame($object1, $result[0]);
+        $this->assertSame($object2, $result[1]);
+    }
+
+    public function testIdTemplateParamCassAndName(): void
+    {
+        $object1 = new DateTimeImmutable();
+        $object2 = new DateTimeImmutable();
+
+        $container = $this->getContainer([
+            'DateTimeInterface$param1' => $object1,
+            'DateTimeInterface$param2' => $object2,
+        ]);
+        $injector = (new Injector($container))
+            ->withIdTemplates(Injector::ID_TEMPLATE_PARAM_CLASS . '$' . Injector::ID_TEMPLATE_PARAM_NAME);
+
+        $result = $injector->invoke(fn (DateTimeInterface $param1, DateTimeInterface $param2) => [$param1, $param2]);
+
+        $this->assertSame($object1, $result[0]);
+        $this->assertSame($object2, $result[1]);
+    }
 }

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -741,7 +741,7 @@ class InjectorTest extends BaseInjectorTest
         $container = $this->getContainer([]);
         $injector1 = new Injector($container);
 
-        $injector2 = $injector1->withIdTemplates(Injector::ID_TEMPLATE_PARAM_CLASS . '$');
+        $injector2 = $injector1->withIdTemplates(Injector::TEMPLATE_PARAM_CLASS . '$');
 
         $this->assertNotSame($injector1, $injector2);
     }
@@ -755,7 +755,7 @@ class InjectorTest extends BaseInjectorTest
             'param1' => $object1,
             'param2' => $object2,
         ]);
-        $injector = (new Injector($container))->withIdTemplates(Injector::ID_TEMPLATE_PARAM_NAME);
+        $injector = (new Injector($container))->withIdTemplates(Injector::TEMPLATE_PARAM_NAME);
 
         $result = $injector->invoke(fn (DateTimeInterface $param1, DateTimeInterface $param2) => [$param1, $param2]);
 
@@ -773,7 +773,7 @@ class InjectorTest extends BaseInjectorTest
             'DateTimeInterface$param2' => $object2,
         ]);
         $injector = (new Injector($container))
-            ->withIdTemplates(Injector::ID_TEMPLATE_PARAM_CLASS . '$' . Injector::ID_TEMPLATE_PARAM_NAME);
+            ->withIdTemplates(Injector::TEMPLATE_PARAM_CLASS . '$' . Injector::TEMPLATE_PARAM_NAME);
 
         $result = $injector->invoke(fn (DateTimeInterface $param1, DateTimeInterface $param2) => [$param1, $param2]);
 
@@ -792,8 +792,8 @@ class InjectorTest extends BaseInjectorTest
         ]);
         $injector = (new Injector($container))
             ->withIdTemplates(
-                Injector::ID_TEMPLATE_PARAM_CLASS . '$' . Injector::ID_TEMPLATE_PARAM_NAME,
-                Injector::ID_TEMPLATE_PARAM_CLASS,
+                Injector::TEMPLATE_PARAM_CLASS . '$' . Injector::TEMPLATE_PARAM_NAME,
+                Injector::TEMPLATE_PARAM_CLASS,
             );
 
         $result = $injector->invoke(fn (DateTimeInterface $param1, DateTimeInterface $param2) => [$param1, $param2]);


### PR DESCRIPTION
I offer a more flexible option for formatting an identifier for use with a container than in #31

For the case of @mj4444ru the injector setting will be as follows:

```php
(new Injector($container))->withIdTemplate(
    Injector::TEMPLATE_PARAM_CLASS . '$' . Injector::TEMPLATE_PARAM_NAME,
    Injector::TEMPLATE_PARAM_CLASS
);
```


### Todo

- [x] More markers
- [ ] Better naming
- [ ] Documentation
  - [ ] Ru
  - [ ] En
  - [ ] Comments
- [ ] More test