### PR TITLE
Testing in PHP 8.1 + Add test invoke object with magic method `__callStatic()`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         php:
           - "7.4"
           - "8.0"
+          - "8.1"
 
     steps:
       - name: Checkout

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -11,6 +11,7 @@ finder:
     - views
     - public
     - templates
+    - tests/Common/Support
   not-name:
     - UnionCar.php
     - TimerUnionTypes.php

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -13,6 +13,8 @@ use Yiisoft\Injector\Injector;
 use Yiisoft\Injector\InvalidArgumentException;
 use Yiisoft\Injector\MissingRequiredArgumentException;
 use Yiisoft\Injector\Tests\Common\Support\CallStaticObject;
+use Yiisoft\Injector\Tests\Common\Support\CallStaticWithSelfObject;
+use Yiisoft\Injector\Tests\Common\Support\CallStaticWithStaticObject;
 use Yiisoft\Injector\Tests\Common\Support\ColorInterface;
 use Yiisoft\Injector\Tests\Common\Support\EngineInterface;
 use Yiisoft\Injector\Tests\Common\Support\EngineMarkTwo;
@@ -25,6 +27,8 @@ use Yiisoft\Injector\Tests\Common\Support\MakeEngineCollector;
 use Yiisoft\Injector\Tests\Common\Support\MakeEngineMatherWithParam;
 use Yiisoft\Injector\Tests\Common\Support\MakeNoConstructor;
 use Yiisoft\Injector\Tests\Common\Support\MakePrivateConstructor;
+use Yiisoft\Injector\Tests\Common\Support\StaticWithSelfObject;
+use Yiisoft\Injector\Tests\Common\Support\StaticWithStaticObject;
 
 class InjectorTest extends BaseInjectorTest
 {
@@ -73,6 +77,28 @@ class InjectorTest extends BaseInjectorTest
         $container = $this->getContainer();
 
         $result = (new Injector($container))->invoke([CallStaticObject::class, 'foo']);
+
+        $this->assertSame('bar', $result);
+    }
+
+    public function dataInvokeStaticWithStaticCalls(): array
+    {
+        return [
+            [CallStaticWithStaticObject::class],
+            [CallStaticWithSelfObject::class],
+            [StaticWithStaticObject::class],
+            [StaticWithSelfObject::class],
+        ];
+    }
+
+    /**
+     * @dataProvider dataInvokeStaticWithStaticCalls
+     */
+    public function testInvokeStaticWithStaticCalls(string $className): void
+    {
+        $container = $this->getContainer();
+
+        $result = (new Injector($container))->invoke([$className, 'foo']);
 
         $this->assertSame('bar', $result);
     }

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -84,6 +84,7 @@ class InjectorTest extends BaseInjectorTest
     public function dataInvokeStaticWithStaticCalls(): array
     {
         return [
+            [CallStaticWithStaticObject::class],
             [CallStaticWithSelfObject::class],
             [StaticWithStaticObject::class],
             [StaticWithSelfObject::class],
@@ -95,23 +96,18 @@ class InjectorTest extends BaseInjectorTest
      */
     public function testInvokeStaticWithStaticCalls(string $className): void
     {
+        if (
+            $className === CallStaticWithStaticObject::class
+            && version_compare(PHP_VERSION, '8.1.0', '<')
+        ) {
+            /** @link https://bugs.php.net/bug.php?id=81626 */
+            $this->markTestSkipped('Bug in PHP version below 8.1. See https://bugs.php.net/bug.php?id=81626');
+        }
         $container = $this->getContainer();
 
         $result = (new Injector($container))->invoke([$className, 'foo']);
 
         $this->assertSame('bar', $result);
-    }
-
-    /**
-     * @link https://bugs.php.net/bug.php?id=81626
-     */
-    public function testInvokeStaticWithStaticCallsBug(): void
-    {
-        $container = $this->getContainer();
-
-        $this->expectError();
-        $this->expectErrorMessage('Cannot access "static" when no class scope is active');
-        (new Injector($container))->invoke([CallStaticWithStaticObject::class, 'foo']);
     }
 
     /**

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -98,7 +98,7 @@ class InjectorTest extends BaseInjectorTest
     {
         if (
             $className === CallStaticWithStaticObject::class
-            && version_compare(PHP_VERSION, '8.1.0', '<')
+            && version_compare(PHP_VERSION, '8.1-dev', '<')
         ) {
             /** @link https://bugs.php.net/bug.php?id=81626 */
             $this->markTestSkipped('Bug in PHP version below 8.1. See https://bugs.php.net/bug.php?id=81626');

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -84,7 +84,6 @@ class InjectorTest extends BaseInjectorTest
     public function dataInvokeStaticWithStaticCalls(): array
     {
         return [
-            [CallStaticWithStaticObject::class],
             [CallStaticWithSelfObject::class],
             [StaticWithStaticObject::class],
             [StaticWithSelfObject::class],
@@ -101,6 +100,18 @@ class InjectorTest extends BaseInjectorTest
         $result = (new Injector($container))->invoke([$className, 'foo']);
 
         $this->assertSame('bar', $result);
+    }
+
+    /**
+     * @link https://bugs.php.net/bug.php?id=81626
+     */
+    public function testInvokeStaticWithStaticCallsBug(): void
+    {
+        $container = $this->getContainer();
+
+        $this->expectError();
+        $this->expectErrorMessage('Cannot access "static" when no class scope is active');
+        (new Injector($container))->invoke([CallStaticWithStaticObject::class, 'foo']);
     }
 
     /**

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -12,6 +12,7 @@ use stdClass;
 use Yiisoft\Injector\Injector;
 use Yiisoft\Injector\InvalidArgumentException;
 use Yiisoft\Injector\MissingRequiredArgumentException;
+use Yiisoft\Injector\Tests\Common\Support\CallStaticObject;
 use Yiisoft\Injector\Tests\Common\Support\ColorInterface;
 use Yiisoft\Injector\Tests\Common\Support\EngineInterface;
 use Yiisoft\Injector\Tests\Common\Support\EngineMarkTwo;
@@ -65,6 +66,15 @@ class InjectorTest extends BaseInjectorTest
         $result = (new Injector($container))->invoke([EngineVAZ2101::class, 'isWroomWroom']);
 
         $this->assertIsBool($result);
+    }
+
+    public function testInvokeCallStatic(): void
+    {
+        $container = $this->getContainer();
+
+        $result = (new Injector($container))->invoke([CallStaticObject::class, 'foo']);
+
+        $this->assertSame('bar', $result);
     }
 
     /**

--- a/tests/Common/Support/CallStaticObject.php
+++ b/tests/Common/Support/CallStaticObject.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Common\Support;
+
+use Exception;
+
+final class CallStaticObject
+{
+    public static function __callStatic(string $name, array $args): string
+    {
+        if ($name === 'foo') {
+            return 'bar';
+        }
+        throw new Exception('Unknown method.');
+    }
+}

--- a/tests/Common/Support/CallStaticWithSelfObject.php
+++ b/tests/Common/Support/CallStaticWithSelfObject.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Common\Support;
+
+use Exception;
+
+final class CallStaticWithSelfObject
+{
+    public static bool $wasCalled = false;
+
+    public static function __callStatic(string $name, array $args): string
+    {
+        if ($name === 'foo') {
+            self::$wasCalled = true;
+            return 'bar';
+        }
+        throw new Exception('Unknown method.');
+    }
+}

--- a/tests/Common/Support/CallStaticWithStaticObject.php
+++ b/tests/Common/Support/CallStaticWithStaticObject.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Common\Support;
+
+use Exception;
+
+final class CallStaticWithStaticObject
+{
+    public static bool $wasCalled = false;
+
+    public static function __callStatic(string $name, array $args): string
+    {
+        if ($name === 'foo') {
+            static::$wasCalled = true;
+            return 'bar';
+        }
+        throw new Exception('Unknown method.');
+    }
+}

--- a/tests/Common/Support/StaticWithSelfObject.php
+++ b/tests/Common/Support/StaticWithSelfObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Common\Support;
+
+final class StaticWithSelfObject
+{
+    public static bool $wasCalled = false;
+
+    public static function foo(): string
+    {
+        self::$wasCalled = true;
+        return 'bar';
+    }
+}

--- a/tests/Common/Support/StaticWithStaticObject.php
+++ b/tests/Common/Support/StaticWithStaticObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Injector\Tests\Common\Support;
+
+final class StaticWithStaticObject
+{
+    public static bool $wasCalled = false;
+
+    public static function foo(): string
+    {
+        static::$wasCalled = true;
+        return 'bar';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #57 
