### PR TITLE
Fix callable call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 under development
 
-- no changes in this release.
+- Enh #98: Fix callable call (@xepozz)
 
 ## 1.2.0 December 20, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 under development
 
-- Enh #98: Fix callable call (@xepozz)
+- Enh #98: Refactor `Injector::invoke()` to improve debug trace (@xepozz)
 
 ## 1.2.0 December 20, 2023
 

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -83,7 +83,7 @@ final class Injector
     {
         $callable = Closure::fromCallable($callable);
         $reflection = new ReflectionFunction($callable);
-        return ($callable)(...$this->resolveDependencies($reflection, $arguments));
+        return $callable(...$this->resolveDependencies($reflection, $arguments));
     }
 
     /**

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -83,7 +83,7 @@ final class Injector
     {
         $callable = Closure::fromCallable($callable);
         $reflection = new ReflectionFunction($callable);
-        return $reflection->invokeArgs($this->resolveDependencies($reflection, $arguments));
+        return ($callable)(...$this->resolveDependencies($reflection, $arguments));
     }
 
     /**

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -654,8 +654,8 @@ class InjectorTest extends BaseInjectorTest
         $traces = $e->getTrace();
 
         foreach ($traces as $trace) {
-            $this->assertArrayHasKey('line',$trace);
-            $this->assertArrayHasKey('file',$trace);
+            $this->assertArrayHasKey('line', $trace);
+            $this->assertArrayHasKey('file', $trace);
         }
     }
 

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -639,6 +639,26 @@ class InjectorTest extends BaseInjectorTest
         (new Injector($container))->invoke($callable, [new \SplStack()]);
     }
 
+    public function testBacktraceContaintsRequiredInfo(): void
+    {
+        $callable = fn () => throw new \Exception();
+
+        $e = null;
+        try {
+            (new Injector())->invoke($callable);
+        } catch (\Exception $e) {
+        }
+
+        $this->assertNotNull($e);
+
+        $traces = $e->getTrace();
+
+        foreach ($traces as $trace) {
+            $this->assertArrayHasKey('line',$trace);
+            $this->assertArrayHasKey('file',$trace);
+        }
+    }
+
     public function testUnnamedScalarParam(): void
     {
         $container = $this->getContainer();

--- a/tests/Common/InjectorTest.php
+++ b/tests/Common/InjectorTest.php
@@ -641,7 +641,9 @@ class InjectorTest extends BaseInjectorTest
 
     public function testBacktraceContaintsRequiredInfo(): void
     {
-        $callable = fn () => throw new \Exception();
+        $callable = function () {
+            throw new \Exception();
+        };
 
         $e = null;
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Reflections and other internal functions don't provide necessary information such as `line` or `file` if they're used during trace. So changing callable call to a regular `$callable(...$args)` solves this. There're proves:

### Current version
<img width="1326" alt="image" src="https://github.com/yiisoft/injector/assets/6815714/eff42788-92c1-41ba-b437-6774f1e467e0">
<img width="759" alt="image" src="https://github.com/yiisoft/injector/assets/6815714/2d4e431b-523b-4eac-b379-a069622cbfe4">

### Fixed version
<img width="1332" alt="image" src="https://github.com/yiisoft/injector/assets/6815714/f49c3977-a820-41e3-a6e3-4329b39137e3">
<img width="723" alt="image" src="https://github.com/yiisoft/injector/assets/6815714/6cfbae76-579c-4281-ad57-7d174f85a564">


