### PR TITLE
Enhance type annotations for `Injector::invoke()`

### DIFF
--- a/src/Injector.php
+++ b/src/Injector.php
@@ -69,7 +69,9 @@ final class Injector
      * This will pass the string `'Hello World!'` as the first argument, and a formatter instance created
      * by the DI container as the second argument.
      *
-     * @param callable $callable callable to be invoked.
+     * @template TReturn
+     *
+     * @param callable(): TReturn $callable callable to be invoked.
      * @param array $arguments The array of the function arguments.
      * This can be either a list of arguments, or an associative array where keys are argument names.
      *
@@ -78,6 +80,9 @@ final class Injector
      * @throws ReflectionException
      *
      * @return mixed The callable return value.
+     *
+     * @psalm-param callable(...): TReturn $callable
+     * @psalm-return TReturn
      */
     public function invoke(callable $callable, array $arguments = [])
     {

--- a/src/InvalidArgumentException.php
+++ b/src/InvalidArgumentException.php
@@ -7,5 +7,5 @@ namespace Yiisoft\Injector;
 final class InvalidArgumentException extends ArgumentException
 {
     protected const EXCEPTION_MESSAGE = 'Invalid argument "%s" when calling "%s"%s. Non-interface argument should be'
-    . ' named explicitly when passed.';
+        . ' named explicitly when passed.';
 }

--- a/src/MissingInternalArgumentException.php
+++ b/src/MissingInternalArgumentException.php
@@ -7,5 +7,5 @@ namespace Yiisoft\Injector;
 final class MissingInternalArgumentException extends ArgumentException
 {
     protected const EXCEPTION_MESSAGE = 'Can not determine default value of parameter "%s" when calling "%s"%s because'
-    . ' it is PHP internal. Please specify argument explicitly.';
+        . ' it is PHP internal. Please specify argument explicitly.';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

PHPStrom doesn't accept `callable(...): TReturn` that's why I had to use `@template` without `psalm` prefix